### PR TITLE
docs: clarify WindDownBanner leaf placement

### DIFF
--- a/src/app/components/WindDownBanner.tsx
+++ b/src/app/components/WindDownBanner.tsx
@@ -16,7 +16,7 @@ export default function WindDownBanner() {
         Visit Wind Down Wednesday
       </Link>
 
-      {/* Leaves should be inside the layout wrapper, not constrained to the section */}
+      {/* Decorative leaves positioned absolutely within the section */}
       <div className="hidden lg:block absolute inset-0 pointer-events-none">
         <Image
           src="/banner-leaves.png"


### PR DESCRIPTION
## Summary
- clarify comment describing decorative leaves placement in WindDownBanner

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to load config "prettier" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_689394c7e2ac832fbaf293315e72beda